### PR TITLE
fix container at head, build form source, use stable releases

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,11 +1,41 @@
+FROM lsiobase/ubuntu:arm64v8-bionic as buildstage
+
+# version tag
+ARG BOOKSONIC_RELEASE
+
+RUN \
+ echo "**** install build packages ****" && \
+ apt-get update && \
+ apt-get install -y \
+        git \
+        jq \
+        openjdk-8-jdk && \
+ apt-get install -y \
+        --no-install-recommends \
+	maven 
+RUN \
+ echo "**** Get and checkout source at version ****" && \
+ if [ -z ${BOOKSONIC_RELEASE+x} ]; then \
+	BOOKSONIC_RELEASE=$(curl -sX GET "https://api.github.com/repos/popeen/Popeens-Subsonic/releases/latest" \
+	| jq -r '. | .tag_name'); \
+ fi && \
+ git clone https://github.com/popeen/Popeens-Subsonic.git /booksonic && \
+ cd /booksonic && \
+ git checkout ${BOOKSONIC_RELEASE}
+
+RUN \
+ echo "**** build war ****" && \
+ cd /booksonic && \
+ mvn clean package
+
+# runtime stage
 FROM lsiobase/ubuntu:arm64v8-bionic
 
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG BOOKSONIC_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="sparklyballsi,thelamer"
 
 # copy prebuild files
 COPY prebuilds/ /prebuilds/
@@ -21,15 +51,14 @@ RUN \
  echo "**** install runtime packages ****" && \
  apt-get update && \
  apt-get install -y \
-        --no-install-recommends \
-        ca-certificates \
-        ffmpeg \
-        flac \
-        fontconfig \
-        jq \
-        lame \
-        openjdk-8-jre-headless \
-        ttf-dejavu && \
+	--no-install-recommends \
+	ca-certificates \
+	ffmpeg \
+	flac \
+	fontconfig \
+	lame \
+	openjdk-8-jre-headless \
+	ttf-dejavu && \
  echo "**** fix XXXsonic status page ****" && \
  find /etc -name "accessibility.properties" -exec rm -fv '{}' + && \
  find /usr -name "accessibility.properties" -exec rm -fv '{}' + && \
@@ -44,16 +73,8 @@ RUN \
  install -m644 -D "jetty-runner-$JETTY_VER.jar" \
 	/usr/share/java/jetty-runner.jar && \
  install -m755 -D jetty-runner /usr/bin/jetty-runner && \
- echo "**** install booksonic ****" && \
- if [ -z ${BOOKSONIC_RELEASE+x} ]; then \
-	BOOKSONIC_RELEASE=$(curl -sX GET "https://api.github.com/repos/popeen/Popeens-Subsonic/releases" \
-	| jq -r '.[0] | .tag_name'); \
- fi && \
  mkdir -p \
 	/app/booksonic && \
- curl -o \
- /app/booksonic/booksonic.war -L \
-	"https://github.com/popeen/Popeens-Subsonic/releases/download/${BOOKSONIC_RELEASE}/booksonic.war" && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \
@@ -62,6 +83,7 @@ RUN \
 
 # add local files
 COPY root/ /
+COPY --from=buildstage /booksonic/subsonic-main/target/booksonic.war /app/booksonic/booksonic.war
 
 # ports and volumes
 EXPOSE 4040

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,11 +1,41 @@
+FROM lsiobase/ubuntu:arm32v7-bionic as buildstage
+
+# version tag
+ARG BOOKSONIC_RELEASE
+
+RUN \
+ echo "**** install build packages ****" && \
+ apt-get update && \
+ apt-get install -y \
+        git \
+        jq \
+        openjdk-8-jdk && \
+ apt-get install -y \
+        --no-install-recommends \
+	maven 
+RUN \
+ echo "**** Get and checkout source at version ****" && \
+ if [ -z ${BOOKSONIC_RELEASE+x} ]; then \
+	BOOKSONIC_RELEASE=$(curl -sX GET "https://api.github.com/repos/popeen/Popeens-Subsonic/releases/latest" \
+	| jq -r '. | .tag_name'); \
+ fi && \
+ git clone https://github.com/popeen/Popeens-Subsonic.git /booksonic && \
+ cd /booksonic && \
+ git checkout ${BOOKSONIC_RELEASE}
+
+RUN \
+ echo "**** build war ****" && \
+ cd /booksonic && \
+ mvn clean package
+
+# runtime stage
 FROM lsiobase/ubuntu:arm32v7-bionic
 
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG BOOKSONIC_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="sparklyballsi,thelamer"
 
 # copy prebuild files
 COPY prebuilds/ /prebuilds/
@@ -21,15 +51,14 @@ RUN \
  echo "**** install runtime packages ****" && \
  apt-get update && \
  apt-get install -y \
-        --no-install-recommends \
-        ca-certificates \
-        ffmpeg \
-        flac \
-        fontconfig \
-        jq \
-        lame \
-        openjdk-8-jre-headless \
-        ttf-dejavu && \
+	--no-install-recommends \
+	ca-certificates \
+	ffmpeg \
+	flac \
+	fontconfig \
+	lame \
+	openjdk-8-jre-headless \
+	ttf-dejavu && \
  echo "**** fix XXXsonic status page ****" && \
  find /etc -name "accessibility.properties" -exec rm -fv '{}' + && \
  find /usr -name "accessibility.properties" -exec rm -fv '{}' + && \
@@ -44,16 +73,8 @@ RUN \
  install -m644 -D "jetty-runner-$JETTY_VER.jar" \
 	/usr/share/java/jetty-runner.jar && \
  install -m755 -D jetty-runner /usr/bin/jetty-runner && \
- echo "**** install booksonic ****" && \
- if [ -z ${BOOKSONIC_RELEASE+x} ]; then \
-	BOOKSONIC_RELEASE=$(curl -sX GET "https://api.github.com/repos/popeen/Popeens-Subsonic/releases" \
-	| jq -r '.[0] | .tag_name'); \
- fi && \
  mkdir -p \
 	/app/booksonic && \
- curl -o \
- /app/booksonic/booksonic.war -L \
-	"https://github.com/popeen/Popeens-Subsonic/releases/download/${BOOKSONIC_RELEASE}/booksonic.war" && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \
@@ -62,6 +83,7 @@ RUN \
 
 # add local files
 COPY root/ /
+COPY --from=buildstage /booksonic/subsonic-main/target/booksonic.war /app/booksonic/booksonic.war
 
 # ports and volumes
 EXPOSE 4040

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,23 +94,23 @@ pipeline {
     /* ########################
        External Release Tagging
        ######################## */
-    // If this is a devel github release use the first in an array from github to determine the ext tag
-    stage("Set ENV github_devel"){
-      steps{
-        script{
-          env.EXT_RELEASE = sh(
-            script: '''curl -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases | jq -r '.[0] | .tag_name' ''',
-            returnStdout: true).trim()
-        }
-      }
+    // If this is a stable github release use the latest endpoint from github to determine the ext tag
+    stage("Set ENV github_stable"){
+     steps{
+       script{
+         env.EXT_RELEASE = sh(
+           script: '''curl -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest | jq -r '. | .tag_name' ''',
+           returnStdout: true).trim()
+       }
+     }
     }
     // If this is a stable or devel github release generate the link for the build message
     stage("Set ENV github_link"){
-      steps{
-        script{
-          env.RELEASE_LINK = 'https://github.com/' + env.EXT_USER + '/' + env.EXT_REPO + '/releases/tag/' + env.EXT_RELEASE
-        }
-      }
+     steps{
+       script{
+         env.RELEASE_LINK = 'https://github.com/' + env.EXT_USER + '/' + env.EXT_REPO + '/releases/tag/' + env.EXT_RELEASE
+       }
+     }
     }
     // Sanitize the release tag and strip illegal docker or github characters
     stage("Sanitize tag"){
@@ -597,7 +597,7 @@ pipeline {
              "tagger": {"name": "LinuxServer Jenkins","email": "jenkins@linuxserver.io","date": "'${GITHUB_DATE}'"}}' '''
         echo "Pushing New release for Tag"
         sh '''#! /bin/bash
-              curl -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases | jq '.[0] |.body' | sed 's:^.\\(.*\\).$:\\1:' > releasebody.json
+              curl -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest | jq '. |.body' | sed 's:^.\\(.*\\).$:\\1:' > releasebody.json
               echo '{"tag_name":"'${EXT_RELEASE_CLEAN}'-pkg-'${PACKAGE_TAG}'-ls'${LS_TAG_NUMBER}'",\
                      "target_commitish": "master",\
                      "name": "'${EXT_RELEASE_CLEAN}'-pkg-'${PACKAGE_TAG}'-ls'${LS_TAG_NUMBER}'",\

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Below are the instructions for updating containers:
 
 ## Versions
 
+* **30.04.19:** - Switching to build war from source, use stable booksonic releases.
 * **24.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **16.01.19:** - Adding pipeline logic and multi arch.
 * **05.01.19:** - Linting fixes.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,7 +2,7 @@
 
 # jenkins variables
 project_name: docker-booksonic
-external_type: github_devel
+external_type: github_stable
 release_type: stable
 release_tag: latest
 ls_branch: master

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -36,6 +36,7 @@ app_setup_block: "Default user/pass is admin/admin"
 
 # changelog
 changelogs:
+  - { date: "30.04.19:", desc: "Switching to build war from source, use stable booksonic releases." }
   - { date: "24.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "16.01.19:", desc: "Adding pipeline logic and multi arch." }
   - { date: "05.01.19:", desc: "Linting fixes." }


### PR DESCRIPTION
There is some kind of weird bug with their war, if we build it agains openjdk-8 in a build container it seems to alleviate it. 

As this is a major overhaul we need local testing, but we are broken at head so can be a stepping stone to what we currently have. 